### PR TITLE
Adds SMTP email sender

### DIFF
--- a/src/EmailTestApp/Properties/launchSettings.json
+++ b/src/EmailTestApp/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "EmailTestApp": {
+      "commandName": "Project"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker"
+    }
+  }
+}

--- a/src/Starbender.RecipeApp.Services.Contracts/RecipeServiceContractsModule.cs
+++ b/src/Starbender.RecipeApp.Services.Contracts/RecipeServiceContractsModule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Starbender.Core;
 using Starbender.Core.Extensions;
 using Starbender.RecipeApp.Domain.Shared;

--- a/src/Starbender.RecipeApp.Services.Contracts/SmtpEmailSenderOptions.cs
+++ b/src/Starbender.RecipeApp.Services.Contracts/SmtpEmailSenderOptions.cs
@@ -1,0 +1,24 @@
+namespace Starbender.RecipeApp.Services.Contracts;
+
+public sealed class SmtpEmailSenderOptions
+{
+    public const string ConfigurationSection = "Email:Smtp";
+
+    public bool Enabled { get; set; }
+
+    public string? Host { get; set; }
+
+    public int Port { get; set; } = 25;
+
+    public bool UseSsl { get; set; }
+
+    public bool UseDefaultCredentials { get; set; }
+
+    public string? UserName { get; set; }
+
+    public string? Password { get; set; }
+
+    public string? FromAddress { get; set; }
+
+    public string? FromName { get; set; }
+}

--- a/src/Starbender.RecipeApp.Services/IdentityNoOpEmailSender.cs
+++ b/src/Starbender.RecipeApp.Services/IdentityNoOpEmailSender.cs
@@ -2,10 +2,10 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Starbender.RecipeApp.EntityFrameworkCore;
 
-namespace Starbender.RecipeApp.Components.Account
+namespace Starbender.RecipeApp.Services
 {
     // Remove the "else if (EmailSender is IdentityNoOpEmailSender)" block from RegisterConfirmation.razor after updating with a real implementation.
-    internal sealed class IdentityNoOpEmailSender : IEmailSender<ApplicationUser>
+    public sealed class IdentityNoOpEmailSender : IEmailSender<ApplicationUser>
     {
         private readonly IEmailSender emailSender = new NoOpEmailSender();
 

--- a/src/Starbender.RecipeApp.Services/IdentitySmtpEmailSender.cs
+++ b/src/Starbender.RecipeApp.Services/IdentitySmtpEmailSender.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Mail;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Starbender.RecipeApp.EntityFrameworkCore;
+using Starbender.RecipeApp.Services.Contracts;
+
+namespace Starbender.RecipeApp.Services;
+
+public sealed class IdentitySmtpEmailSender(
+    IOptions<SmtpEmailSenderOptions> options,
+    ILogger<IdentitySmtpEmailSender> logger) : IEmailSender<ApplicationUser>
+{
+    private readonly SmtpEmailSenderOptions _options = options.Value;
+
+    public Task SendConfirmationLinkAsync(ApplicationUser user, string email, string confirmationLink) =>
+        SendHtmlEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>.");
+
+    public Task SendPasswordResetLinkAsync(ApplicationUser user, string email, string resetLink) =>
+        SendHtmlEmailAsync(email, "Reset your password", $"Please reset your password by <a href='{resetLink}'>clicking here</a>.");
+
+    public Task SendPasswordResetCodeAsync(ApplicationUser user, string email, string resetCode) =>
+        SendTextEmailAsync(email, "Reset your password", $"Please reset your password using the following code: {resetCode}");
+
+    private async Task SendHtmlEmailAsync(string toEmail, string subject, string htmlBody)
+    {
+        ValidateConfiguration();
+
+        using var message = new MailMessage
+        {
+            From = new MailAddress(_options.FromAddress!, _options.FromName),
+            Subject = subject,
+            Body = htmlBody,
+            IsBodyHtml = true
+        };
+        message.To.Add(toEmail);
+
+        using var client = CreateClient();
+        await client.SendMailAsync(message);
+
+        logger.LogInformation("SMTP email sent to {Email} with subject '{Subject}'", toEmail, subject);
+    }
+
+    private async Task SendTextEmailAsync(string toEmail, string subject, string body)
+    {
+        ValidateConfiguration();
+
+        using var message = new MailMessage
+        {
+            From = new MailAddress(_options.FromAddress!, _options.FromName),
+            Subject = subject,
+            Body = body,
+            IsBodyHtml = false
+        };
+        message.To.Add(toEmail);
+
+        using var client = CreateClient();
+        await client.SendMailAsync(message);
+
+        logger.LogInformation("SMTP email sent to {Email} with subject '{Subject}'", toEmail, subject);
+    }
+
+    private SmtpClient CreateClient()
+    {
+        var client = new SmtpClient(_options.Host!, _options.Port)
+        {
+            EnableSsl = _options.UseSsl,
+            UseDefaultCredentials = _options.UseDefaultCredentials
+        };
+
+        if (!_options.UseDefaultCredentials && !string.IsNullOrWhiteSpace(_options.UserName))
+        {
+            client.Credentials = new NetworkCredential(_options.UserName, _options.Password);
+        }
+
+        return client;
+    }
+
+    private void ValidateConfiguration()
+    {
+        if (!_options.Enabled)
+        {
+            throw new InvalidOperationException("SMTP email sender is not enabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.Host))
+        {
+            throw new InvalidOperationException("Email:Smtp:Host is required when SMTP email is enabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.FromAddress))
+        {
+            throw new InvalidOperationException("Email:Smtp:FromAddress is required when SMTP email is enabled.");
+        }
+    }
+}

--- a/src/Starbender.RecipeApp.Services/RecipeServicesModule.cs
+++ b/src/Starbender.RecipeApp.Services/RecipeServicesModule.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Starbender.Core;
 using Starbender.Core.Extensions;
@@ -24,6 +26,25 @@ public class RecipeServicesModule : ModuleBase
             .BindConfiguration(RecipeAppOptions.ConfigurationKey)
             .ValidateOnStart();
 
+        ConfigureEmailSender(services);
+
         return services;
+    }
+
+    private void ConfigureEmailSender(IServiceCollection services)
+    {
+        var configuration = services.BuildServiceProvider().GetRequiredService<IConfiguration>();
+
+        services.AddOptions<SmtpEmailSenderOptions>()
+            .BindConfiguration(SmtpEmailSenderOptions.ConfigurationSection);
+
+        if (configuration.GetValue<bool>("Email:Smtp:Enabled"))
+        {
+            services.AddSingleton<IEmailSender<ApplicationUser>, IdentitySmtpEmailSender>();
+        }
+        else
+        {
+            services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSender>();
+        }
     }
 }

--- a/src/Starbender.RecipeApp/Components/Account/Pages/RegisterConfirmation.razor
+++ b/src/Starbender.RecipeApp/Components/Account/Pages/RegisterConfirmation.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
 @using Starbender.RecipeApp.EntityFrameworkCore
+@using Starbender.RecipeApp.Services
 
 @inject UserManager<ApplicationUser> UserManager
 @inject IEmailSender<ApplicationUser> EmailSender

--- a/src/Starbender.RecipeApp/Program.cs
+++ b/src/Starbender.RecipeApp/Program.cs
@@ -157,8 +157,6 @@ namespace Starbender.RecipeApp
                 .AddSignInManager()
                 .AddDefaultTokenProviders();
 
-            builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSender>();
-
             // Custom module dependency loader
             builder.Services.InitializeAppModules();
 

--- a/src/Starbender.RecipeApp/appsettings.json
+++ b/src/Starbender.RecipeApp/appsettings.json
@@ -33,6 +33,19 @@
       "SignedOutCallbackPath": "/signout-callback-oidc"
     }
   },
+  "Email": {
+    "Smtp": {
+      "Enabled": true,
+      "Host": "smtp.azurecomm.net",
+      "Port": 587,
+      "UseSsl": true,
+      "UseDefaultCredentials": false,
+      "UserName": "",
+      "Password": "",
+      "FromName": "Recipe App",
+      "FromAddress": ""
+    }
+  },
   "ConnectionStrings": {
     "Default": "Server=localhost;Database=RecipeDb;User Id=recipeapp;Password=<PASSWORD>;TrustServerCertificate=True;"
   },

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       ConnectionStrings__Default: "Server=sqlserver;Database=RecipeDb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=True;"
       # Bootstrap admin (optional)
       Authorization__BootstrapUser__Enabled: "true"
-      Authorization__BootstrapUser__Email: "admin@recipeapp.starbendersystems.com"
-      Authorization__BootstrapUser__UserName: "admin@recipeapp.starbendersystems.com"
+      Authorization__BootstrapUser__Email: "<ADMIN_EMAIL>"
+      Authorization__BootstrapUser__UserName: "<ADMIN_USERNAME>"
       Authorization__BootstrapUser__Password: "Use-A-Real-Secret"
       Authorization__BootstrapUser__AutoCreate: "true"
       Authorization__BootstrapUser__Permissions__0: "ManageSecurity"


### PR DESCRIPTION
Implements SMTP email functionality for user account confirmation and password reset.

Configures SMTP settings via appsettings and environment variables. Adds an option to disable SMTP and fallback to a no-op email sender. Replaces hardcoded admin credentials with configurable placeholders.

Fixes #35